### PR TITLE
Redirect our host to ReadTheDocs

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@
 layout: frontpage
 title: Home
 banner-button-text: VAPOR Documentation
-banner-button-url: https://ncar.github.io/VaporDocumentationWebsite/downloads.html
+banner-button-url: https://vapordocumentationwebsite.readthedocs.io/en/latest/downloads.html
 ---
 
 # Welcome

--- a/pages/DocumentationPage.md
+++ b/pages/DocumentationPage.md
@@ -7,14 +7,14 @@ title: Documentation
 ## Documentation
 
 <p align="left">
-   <a href="https://ncar.github.io/VaporDocumentationWebsite/vaporApplicationReference.html">
+   <a href="https://vapordocumentationwebsite.readthedocs.io/en/latest/vaporApplicationReference.html">
    <img src="../images/vap_gui_doc.png" 
    alt="Trulli" 
    style="width:50%"></a>
 </p>
 
 <p align="left">
-   <a href="https://ncar.github.io/VaporDocumentationWebsite/pythonAPIReference/classReference.html">
+   <a href="https://vapordocumentationwebsite.readthedocs.io/en/latest/pythonAPIReference/classReference.html">
    <img src="../images/vap_py_doc.png" 
    alt="Trulli" 
    style="width:50%"></a>

--- a/pages/DownloadsPage.md
+++ b/pages/DownloadsPage.md
@@ -7,7 +7,7 @@ title: Download
 ## Download and Install
 
 <p align="left">
-   <a href="https://ncar.github.io/VaporDocumentationWebsite/downloads.html">
+   <a href="https://vapordocumentationwebsite.readthedocs.io/en/latest/downloads.html">
    <img src="../images/vaporGUI.png" 
    alt="Trulli" 
    style="width:50%"></a>

--- a/pages/QuickStartPage.md
+++ b/pages/QuickStartPage.md
@@ -7,7 +7,7 @@ title: Quick Start
 ## Quick Start Guides
 
 <p align="left">
-   <a href="https://ncar.github.io/VaporDocumentationWebsite/vaporApplicationReference/quickStartGuide.html">
+   <a href="https://vapordocumentationwebsite.readthedocs.io/en/latest/vaporApplicationReference/quickStartGuide.html">
    <img src="../images/vap_gui_quickstart.png" 
    alt="Trulli" 
    style="width:50%"></a>


### PR DESCRIPTION
This PR redirects our landing-page links to those hosted by ReadTheDocs.  This is in lieu of our links that were hosted by a Github Page that was just raw html, which made made pull request reviews very difficult if not impossible.

Documentation hosted on ReadTheDocs:
https://vapordocumentationwebsite.readthedocs.io/en/latest/